### PR TITLE
Use given columns in empty/placeholder DataFrames

### DIFF
--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -65,9 +65,13 @@ def read_file(filename):
 
             # Process the file in chunks
             chunks = []
-            for chunk in reader:
+            for i, chunk in enumerate(reader):
                 # Cleanup column names just to be safe
                 chunk = chunk.rename(columns=lambda x: x.strip())
+
+                if i == 0:
+                    # Track the actual columns in the file if present
+                    columns = list(chunk.columns)
 
                 # Apply view filters
                 for col, values in view_filters.items():

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -92,13 +92,13 @@ def test_read_file(path, dates, shapes):
 
 @pytest.mark.parametrize('path,shapes', [
     (fixture('empty.zip'), {
-        'agency.txt': (0, 0),
-        'calendar.txt': (0, 0),
-        'calendar_dates.txt': (0, 0),
-        'fare_attributes.txt': (0, 0),
-        'fare_rules.txt': (0, 0),
-        'routes.txt': (0, 0),
-        'stops.txt': (0, 0),
+        'agency.txt': (0, 3),
+        'calendar.txt': (0, 10),
+        'calendar_dates.txt': (0, 3),
+        'fare_attributes.txt': (0, 5),
+        'fare_rules.txt': (0, 1),
+        'routes.txt': (0, 4),
+        'stops.txt': (0, 4),
     }),
     (fixture('caltrain-2017-07-24.zip'), {
         'agency.txt': (1, 6),
@@ -229,3 +229,19 @@ def test_structure(path):
         for member in member_dates:
             assert feed.service_ids_by_date[member] == service_ids
             assert feed.trip_counts_by_date[member] > 0
+
+
+@pytest.mark.parametrize('path', [
+    fixture('amazon-2017-08-06.zip'),
+    fixture('caltrain-2017-07-24.zip'),
+])
+def test_filtered_columns(path):
+    service_ids_by_date = ptg.read_service_ids_by_date(path)
+    service_ids = list(service_ids_by_date.values())[0]
+
+    feed_full = ptg.feed(path)
+    feed_view = ptg.feed(path, view={'trips.txt': {'service_id': service_ids}})
+    feed_null = ptg.feed(path, view={'trips.txt': {'service_id': 'never-match-id'}})
+
+    assert set(feed_full.trips.columns) == set(feed_view.trips.columns)
+    assert set(feed_full.trips.columns) == set(feed_null.trips.columns)


### PR DESCRIPTION
This improves the behavior of two cases:

1. a csv has a header but no rows of data
2. the rows of a csv are completely filtered away

In these cases, the previous behavior was to return an empty
dataframe with no columns or `required_columns` if given.

This change improves behavior in these cases by always
returning a dataframe with columns that match the actual
columns in the file.