### PR TITLE
Factor out a function to write feed objects to a zip

### DIFF
--- a/partridge/writers.py
+++ b/partridge/writers.py
@@ -14,25 +14,27 @@ DEFAULT_NODES = frozenset(default_config().nodes())
 
 
 def extract_agencies(inpath, outpath, agency_ids):
-    return _extract_feed(
-        inpath, outpath,
-        extract_agencies_config(),
-        {'agency.txt': {'agency_id': agency_ids}},
-    )
+    config = extract_agencies_config()
+    view = {'agency.txt': {'agency_id': agency_ids}}
+    feed = mkfeed(inpath, config, view)
+    return write_feed_dangerously(feed, outpath)
 
 
 def extract_routes(inpath, outpath, route_ids):
-    return _extract_feed(
-        inpath, outpath,
-        extract_routes_config(),
-        {'trips.txt': {'route_id': route_ids}},
-    )
-
-
-def _extract_feed(inpath, outpath, config, view):
+    config = extract_routes_config()
+    view = {'trips.txt': {'route_id': route_ids}}
     feed = mkfeed(inpath, config, view)
-    nodes = set(config.nodes()) | DEFAULT_NODES
+    return write_feed_dangerously(feed, outpath)
 
+
+def write_feed_dangerously(feed, outpath, nodes=None):
+    """
+    Naively write a feed to a zipfile
+
+    This function provides no sanity checks. Use it at
+    your own risk.
+    """
+    nodes = DEFAULT_NODES if nodes is None else nodes
     try:
         tmpdir = tempfile.mkdtemp()
 


### PR DESCRIPTION
This function assumes the input feed is well-formed. As the name
indicates, there are no sanity checks.

At Remix we sometimes need to transform GTFS files for downstream
systems that have particular requirements. This function makes
it a breeze to do those transformations with pandas and then
write out a zip file.