### PR TITLE
[RFC] Multi-file filtering

### DIFF
--- a/partridge/__init__.py
+++ b/partridge/__init__.py
@@ -1,6 +1,7 @@
 from partridge.__version__ import __version__
 from partridge.gtfs import feed, raw_feed
 from partridge.readers import (
+    get_filtered_feed,
     get_representative_feed,
     read_busiest_date,
     read_service_ids_by_date,
@@ -17,6 +18,7 @@ __all__ = [
     '__version__',
     'feed',
     'raw_feed',
+    'get_filtered_feed',
     'get_representative_feed',
     'read_busiest_date',
     'read_service_ids_by_date',

--- a/partridge/config.py
+++ b/partridge/config.py
@@ -1,3 +1,5 @@
+# flake8: noqa E501
+
 import networkx as nx
 
 from partridge.parsers import \
@@ -25,67 +27,67 @@ def default_config():
 def add_edge_config(g):
     g.add_edges_from([
         ('agency.txt', 'routes.txt', {
-            'dependencies': {
-                'agency_id': 'agency_id',
-            },
+            'dependencies': [
+                {'agency.txt': 'agency_id', 'routes.txt': 'agency_id'},
+            ],
         }),
         ('calendar.txt', 'trips.txt', {
-            'dependencies': {
-                'service_id': 'service_id',
-            },
+            'dependencies': [
+                {'calendar.txt': 'service_id', 'trips.txt': 'service_id'},
+            ],
         }),
         ('calendar_dates.txt', 'trips.txt', {
-            'dependencies': {
-                'service_id': 'service_id',
-            },
+            'dependencies': [
+                {'calendar_dates.txt': 'service_id', 'trips.txt': 'service_id'},
+            ],
         }),
         ('fare_attributes.txt', 'fare_rules.txt', {
-            'dependencies': {
-                'fare_id': 'fare_id',
-            },
+            'dependencies': [
+                {'fare_attributes.txt': 'fare_id', 'fare_rules.txt': 'fare_id'},
+            ],
         }),
         ('fare_rules.txt', 'stops.txt', {
-            'dependencies': {
-                'origin_id': 'zone_id',
-                'destination_id': 'zone_id',
-                'contains_id': 'zone_id',
-            },
+            'dependencies': [
+                {'fare_rules.txt': 'origin_id', 'stops.txt': 'zone_id'},
+                {'fare_rules.txt': 'destination_id', 'stops.txt': 'zone_id'},
+                {'fare_rules.txt': 'contains_id', 'stops.txt': 'zone_id'},
+            ],
         }),
         ('fare_rules.txt', 'routes.txt', {
-            'dependencies': {
-                'route_id': 'route_id',
-            },
+            'dependencies': [
+                {'fare_rules.txt': 'route_id', 'routes.txt': 'route_id'},
+            ],
         }),
         ('frequencies.txt', 'trips.txt', {
-            'dependencies': {
-                'trip_id': 'trip_id',
-            },
+            'dependencies': [
+                {'frequencies.txt': 'trip_id', 'trips.txt': 'trip_id'},
+            ],
         }),
         ('routes.txt', 'trips.txt', {
-            'dependencies': {
-                'route_id': 'route_id',
-            },
+            'dependencies': [
+                {'routes.txt': 'route_id', 'trips.txt': 'route_id'},
+            ],
         }),
         ('shapes.txt', 'trips.txt', {
-            'dependencies': {
-                'shape_id': 'shape_id',
-            },
+            'dependencies': [
+                {'shapes.txt': 'shape_id', 'trips.txt': 'shape_id'},
+            ],
         }),
         ('stops.txt', 'stop_times.txt', {
-            'dependencies': {
-                'stop_id': 'stop_id',
-            },
+            'dependencies': [
+                {'stops.txt': 'stop_id', 'stop_times.txt': 'stop_id'},
+            ],
         }),
         ('stop_times.txt', 'trips.txt', {
-            'dependencies': {
-                'trip_id': 'trip_id',
-            },
+            'dependencies': [
+                {'stop_times.txt': 'trip_id', 'trips.txt': 'trip_id'},
+            ],
         }),
         ('transfers.txt', 'stops.txt', {
-            'dependencies': {
-                'from_stop_id': 'stop_id',
-                'to_stop_id': 'stop_id',
-            },
+            'dependencies': [
+                {'transfers.txt': 'from_stop_id', 'stops.txt': 'stop_id'},
+                {'transfers.txt': 'to_stop_id', 'stops.txt': 'stop_id'},
+            ],
         }),
     ])
 

--- a/partridge/config.py
+++ b/partridge/config.py
@@ -12,12 +12,6 @@ def empty_config():
     return nx.DiGraph()
 
 
-def config_for_root(root):
-    config = empty_config()
-    add_edge_config(config)
-    return reroot_graph(config, root)
-
-
 '''
 Default configs
 '''

--- a/partridge/config.py
+++ b/partridge/config.py
@@ -12,6 +12,12 @@ def empty_config():
     return nx.DiGraph()
 
 
+def config_for_root(root):
+    config = empty_config()
+    add_edge_config(config)
+    return reroot_graph(config, root)
+
+
 '''
 Default configs
 '''

--- a/partridge/config.py
+++ b/partridge/config.py
@@ -273,22 +273,6 @@ def add_node_config(g):
     ])
 
 
-'''
-Writer configs
-'''
-
-
-def extract_agencies_config():
-    G = empty_config()
-    add_edge_config(G)
-    return reroot_graph(G, 'agency.txt')
-
-
-def extract_routes_config():
-    G = empty_config()
-    add_edge_config(G)
-    return G
-
 
 def reroot_graph(G, node):
     '''Return a copy of the graph rooted at the given node'''

--- a/partridge/config.py
+++ b/partridge/config.py
@@ -275,29 +275,23 @@ Writer configs
 def extract_agencies_config():
     G = empty_config()
     add_edge_config(G)
-
-    G.remove_edges_from([
-        ('routes.txt', 'trips.txt'),
-        ('agency.txt', 'routes.txt'),
-    ])
-
-    G.add_edges_from([
-        ('trips.txt', 'routes.txt', {
-            'dependencies': {
-                'route_id': 'route_id',
-            },
-        }),
-        ('routes.txt', 'agency.txt', {
-            'dependencies': {
-                'agency_id': 'agency_id',
-            },
-        }),
-    ])
-
-    return G
+    return reroot_graph(G, 'agency.txt')
 
 
 def extract_routes_config():
     G = empty_config()
     add_edge_config(G)
+    return G
+
+
+def reroot_graph(G, node):
+    '''Return a copy of the graph rooted at the given node'''
+    G = G.copy()
+    to_add, to_remove = [], []
+    for n, successors in nx.bfs_successors(G, source=node):
+        for s in successors:
+            to_add.append([s, n, G.edges[n, s]])
+            to_remove.append([n, s])
+    G.remove_edges_from(to_remove)
+    G.add_edges_from(to_add)
     return G

--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -74,9 +74,8 @@ class feed(object):
 
         # Gather the dependencies between this file and others
         file_dependencies = {
-            depfile: data['dependencies'].items()
+            depfile: data.get('dependencies', [])
             for _, depfile, data in config.out_edges(filename, data=True)
-            if 'dependencies' in data
         }
 
         # Gather applicable view filter params
@@ -112,11 +111,14 @@ class feed(object):
                         chunk = chunk[chunk[col].isin(values)]
 
                 # Prune the chunk
-                for depfile, dependencies in file_dependencies.items():
+                for depfile, deplist in file_dependencies.items():
                     # Read the filtered, pruned, and cached file dependency
                     depdf = self.get(depfile)
 
-                    for col, depcol in dependencies:
+                    for deps in deplist:
+                        col = deps[filename]
+                        depcol = deps[depfile]
+
                         # If applicable, prune this chunk by the other
                         if col in chunk.columns and depcol in depdf.columns:
                             chunk = chunk[chunk[col].isin(depdf[depcol])]

--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -17,3 +17,16 @@ def setwrap(value):
     one object or a list of objects.
     """
     return set(map(np.unicode, set(flatten([value]))))
+
+
+def remove_node_attributes(G, attributes):
+    """
+    Return a copy of the graph with the given attributes
+    deleted from all nodes.
+    """
+    G = G.copy()
+    for _, data in G.nodes(data=True):
+        for attribute in setwrap(attributes):
+            if attribute in data:
+                del data[attribute]
+    return G

--- a/partridge/writers.py
+++ b/partridge/writers.py
@@ -2,8 +2,9 @@ import os
 import shutil
 import tempfile
 
-from partridge.config import config_for_root, default_config
+from partridge.config import default_config
 from partridge.readers import get_filtered_feed
+from partridge.utilities import remove_node_attributes
 
 
 DEFAULT_NODES = frozenset(default_config().nodes())
@@ -19,8 +20,9 @@ def extract_routes(inpath, outpath, route_ids):
     return extract_feed(inpath, outpath, filters)
 
 
-def extract_feed(inpath, outpath, filters):
-    config = config_for_root('trips.txt')
+def extract_feed(inpath, outpath, filters, config=None):
+    config = default_config() if config is None else config
+    config = remove_node_attributes(config, 'converters')
     feed = get_filtered_feed(inpath, filters, config)
     return write_feed_dangerously(feed, outpath)
 

--- a/partridge/writers.py
+++ b/partridge/writers.py
@@ -2,28 +2,26 @@ import os
 import shutil
 import tempfile
 
-from partridge.config import (
-    default_config,
-    extract_agencies_config,
-    extract_routes_config,
-)
-from partridge.gtfs import feed as mkfeed
+from partridge.config import config_for_root, default_config
+from partridge.readers import get_filtered_feed
 
 
 DEFAULT_NODES = frozenset(default_config().nodes())
 
 
 def extract_agencies(inpath, outpath, agency_ids):
-    config = extract_agencies_config()
-    view = {'agency.txt': {'agency_id': agency_ids}}
-    feed = mkfeed(inpath, config, view)
-    return write_feed_dangerously(feed, outpath)
+    filters = {'routes.txt': {'agency_id': agency_ids}}
+    return extract_feed(inpath, outpath, filters)
 
 
 def extract_routes(inpath, outpath, route_ids):
-    config = extract_routes_config()
-    view = {'trips.txt': {'route_id': route_ids}}
-    feed = mkfeed(inpath, config, view)
+    filters = {'trips.txt': {'route_id': route_ids}}
+    return extract_feed(inpath, outpath, filters)
+
+
+def extract_feed(inpath, outpath, filters):
+    config = config_for_root('trips.txt')
+    feed = get_filtered_feed(inpath, filters, config)
     return write_feed_dangerously(feed, outpath)
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,7 +1,8 @@
 import numpy as np
+import networkx as nx
 import pandas as pd
 
-from partridge.utilities import empty_df, setwrap
+from partridge.utilities import empty_df, setwrap, remove_node_attributes
 
 
 def test_empty_df():
@@ -21,3 +22,20 @@ def test_setwrap():
     assert setwrap({'a'}) == {'a'}
     assert setwrap({1}) == {'1'}
     assert setwrap(1) == {'1'}
+
+
+def test_remove_node_attributes():
+    G = nx.Graph()
+    G.add_node(1, label='foo', hello='world')
+    G.add_node(2, label='bar', welcome=1)
+
+    X = remove_node_attributes(G, 'label')
+    Y = remove_node_attributes(G, ['label', 'welcome'])
+
+    assert id(X) != id(G)
+    assert X.nodes[1] == {'hello': 'world'}
+    assert X.nodes[2] == {'welcome': 1}
+
+    assert id(Y) != id(G)
+    assert Y.nodes[1] == {'hello': 'world'}
+    assert Y.nodes[2] == {}

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -32,6 +32,9 @@ def test_remove_node_attributes():
     X = remove_node_attributes(G, 'label')
     Y = remove_node_attributes(G, ['label', 'welcome'])
 
+    assert G.nodes[1] == {'label': 'foo', 'hello': 'world'}
+    assert G.nodes[2] == {'label': 'bar', 'welcome': 1}
+
     assert id(X) != id(G)
     assert X.nodes[1] == {'hello': 'world'}
     assert X.nodes[2] == {'welcome': 1}


### PR DESCRIPTION
I've tried a bunch of approaches to multi-file filtering and this seemed to be the best option because it:

- preserves complete trips (stops, stop times, etc.)
- abstracts away changes to the config graph
- doesn't add complexity to the feed class

```python
import partridge as ptg

path = 'path/to/gtfs.zip'

_date, service_ids = ptg.read_busiest_date(path)

feed = ptg.get_filtered_feed(path, {
    'agency.txt': {'agency_id': '1'},
    'trips.txt': {'service_id': service_ids},
})
```
