### PR TITLE
Extract function for reading the busiest date and accompanying `service_id`s

### DIFF
--- a/partridge/__init__.py
+++ b/partridge/__init__.py
@@ -2,6 +2,7 @@ from partridge.__version__ import __version__
 from partridge.gtfs import feed, raw_feed
 from partridge.readers import (
     get_representative_feed,
+    read_busiest_date,
     read_service_ids_by_date,
     read_dates_by_service_ids,
     read_trip_counts_by_date,
@@ -17,6 +18,7 @@ __all__ = [
     'feed',
     'raw_feed',
     'get_representative_feed',
+    'read_busiest_date',
     'read_service_ids_by_date',
     'read_dates_by_service_ids',
     'read_trip_counts_by_date',

--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -82,7 +82,7 @@ class feed(object):
         # Gather applicable view filter params
         view_filters = {
             # column name : set of strings
-            col: set(map(np.unicode, setwrap(values)))
+            col: setwrap(values)
             for col, values in self.view.get(filename, {}).items()
         }
 

--- a/partridge/readers.py
+++ b/partridge/readers.py
@@ -27,7 +27,7 @@ def read_busiest_date(path):
     service_ids_by_date = _service_ids_by_date(feed)
     trip_counts_by_date = _trip_counts_by_date(feed)
 
-    date, _ = max(trip_counts_by_date.items(), key=lambda p: p[1])
+    date, _ = max(trip_counts_by_date.items(), key=lambda p: (p[1], p[0]))
     service_ids = service_ids_by_date[date]
 
     return date, service_ids

--- a/partridge/readers.py
+++ b/partridge/readers.py
@@ -14,6 +14,14 @@ DAY_NAMES = (
 
 
 def get_representative_feed(path):
+    '''Return a feed filtered to the busiest date'''
+    _, service_ids = read_busiest_date(path)
+    view = {'trips.txt': {'service_id': service_ids}}
+    return mkfeed(path, view=view)
+
+
+def read_busiest_date(path):
+    '''Find the date with the most trips'''
     feed = raw_feed(path)
 
     service_ids_by_date = _service_ids_by_date(feed)
@@ -21,9 +29,8 @@ def get_representative_feed(path):
 
     date, _ = max(trip_counts_by_date.items(), key=lambda p: p[1])
     service_ids = service_ids_by_date[date]
-    view = {'trips.txt': {'service_id': service_ids}}
 
-    return mkfeed(path, view=view)
+    return date, service_ids
 
 
 def read_service_ids_by_date(path):

--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -10,4 +10,10 @@ def empty_df(columns=None):
 
 
 def setwrap(value):
-    return set(flatten([value]))
+    """
+    Returns a flattened and stringified set from the given object or iterable.
+
+    For use in public functions which accept argmuents or kwargs that can be
+    one object or a list of objects.
+    """
+    return set(map(np.unicode, set(flatten([value]))))

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -11,12 +11,9 @@ from .helpers import fixture, zip_file
     fixture('caltrain-2017-07-24'),
 ])
 def test_get_representative_feed(path):
-    trip_counts_by_date = ptg.read_trip_counts_by_date(path)
-    service_ids_by_date = ptg.read_service_ids_by_date(path)
-    date, _ = max(trip_counts_by_date.items(), key=lambda p: p[1])
-    service_ids = service_ids_by_date[date]
-
+    date, service_ids = ptg.read_busiest_date(path)
     feed = ptg.get_representative_feed(path)
+
     assert isinstance(feed, ptg.feed)
     assert feed.view == {'trips.txt': {'service_id': service_ids}}
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -19,3 +19,5 @@ def test_setwrap():
     assert setwrap('a') == {'a'}
     assert setwrap(['a']) == {'a'}
     assert setwrap({'a'}) == {'a'}
+    assert setwrap({1}) == {'1'}
+    assert setwrap(1) == {'1'}


### PR DESCRIPTION
See commits. This PR also cleans up the `setwrap` utility.

```python
import partridge as ptg
date, service_ids = ptg.read_busiest_date('gtfs.zip')
```
