### PR TITLE
Gracefully handle completely empty files

### DIFF
--- a/tests/fixtures/empty/calendar.txt
+++ b/tests/fixtures/empty/calendar.txt
@@ -1,1 +1,0 @@
-service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -168,7 +168,7 @@ def test_read_file(path, dates, shapes):
 @pytest.mark.parametrize('path,shapes', [
     (zip_file('empty'), {
         'agency.txt': (0, 3),
-        'calendar.txt': (0, 10),
+        'calendar.txt': (0, 0),
         'calendar_dates.txt': (0, 3),
         'fare_attributes.txt': (0, 5),
         'fare_rules.txt': (0, 1),
@@ -197,7 +197,7 @@ def test_read_file(path, dates, shapes):
     }),
     (fixture('empty'), {
         'agency.txt': (0, 3),
-        'calendar.txt': (0, 10),
+        'calendar.txt': (0, 0),
         'calendar_dates.txt': (0, 3),
         'fare_attributes.txt': (0, 5),
         'fare_rules.txt': (0, 1),


### PR DESCRIPTION
This change unifies the behavior of reading from a CSV
with a header only (no data rows) and a completely empty (zero bytes)
file in the zip. We don't run into this much, but it does happen and
the fix is simple.