### PR TITLE
Cache parse_time function

### DIFF
--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -1,8 +1,3 @@
-try:
-    from functools import lru_cache
-except ImportError:
-    from functools32 import lru_cache
-
 from contextlib import contextmanager
 import io
 import os
@@ -13,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from partridge.config import default_config, empty_config
-from partridge.utilities import empty_df, setwrap
+from partridge.utilities import empty_df, lru_cache, setwrap
 
 
 def read_file(filename):

--- a/partridge/parsers.py
+++ b/partridge/parsers.py
@@ -3,9 +3,13 @@ from functools import partial
 import numpy as np
 import pandas as pd
 
+from partridge.utilities import lru_cache
+
 DATE_FORMAT = '%Y%m%d'
 
 
+# Why 2^17? See https://git.io/vxB2P.
+@lru_cache(maxsize=2**17)
 def parse_time(val):
     if val is np.nan:
         return val

--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -1,6 +1,19 @@
+try:
+    from functools import lru_cache
+except ImportError:
+    from functools32 import lru_cache
+
 import numpy as np
 import pandas as pd
 from pandas.core.common import flatten
+
+
+__all__ = [
+    'empty_df',
+    'lru_cache',
+    'remove_node_attributes',
+    'setwrap',
+]
 
 
 def empty_df(columns=None):


### PR DESCRIPTION
Exchange space for time using Python's built-in LRU cache. [Limited analysis](https://gist.github.com/invisiblefunnel/194afdafd72a387f5622950d206e124b) suggests a `maxsize` of 2^17 should cover most cases. This passes the smell test since there are 86,400 seconds in 24 hours.

I didn't take the time to measure memory usage, but my back-of-the-envelope calculations say 5 to 15mb at the high end. Please chime in with feedback.

![parse_time](https://user-images.githubusercontent.com/331023/37861248-0d9e0d90-2ef3-11e8-81f8-aeec70550b90.png)

Benchmarks were taken on a MacBook Pro (Retina, 15-inch, Mid 2015), 2.2 GHz Intel Core i7, 16 GB 1600 MHz DDR3.