### PR TITLE
Codebase gardening

### DIFF
--- a/partridge/config.py
+++ b/partridge/config.py
@@ -267,7 +267,6 @@ def add_node_config(g):
     ])
 
 
-
 def reroot_graph(G, node):
     '''Return a copy of the graph rooted at the given node'''
     G = G.copy()

--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -144,26 +144,23 @@ class feed(object):
             """
             Build a chunked DataFrame reader
             """
-            return pd.read_csv(
-                iowrapper, chunksize=10000,
-                dtype=np.unicode, index_col=False,
-                low_memory=False, skipinitialspace=True)
+            try:
+                return pd.read_csv(
+                    iowrapper, chunksize=10000,
+                    dtype=np.unicode, index_col=False,
+                    low_memory=False, skipinitialspace=True)
+            except pd.errors.EmptyDataError:
+                return iter([])
 
         if self.is_dir:
             with open(self.zmap[filename], 'rb') as iowrapper:
-                try:
-                    yield reader(iowrapper)
-                except pd.errors.EmptyDataError:
-                    yield iter([])
+                yield reader(iowrapper)
         else:
             with ZipFile(self.path) as zipreader:
                 with zipreader.open(self.zmap[filename], 'r') as zfile:
                     with io.TextIOWrapper(zfile,
                                           encoding='utf-8-sig') as iowrapper:
-                        try:
-                            yield reader(iowrapper)
-                        except pd.errors.EmptyDataError:
-                            yield iter([])
+                        yield reader(iowrapper)
 
     def _verify_zip_contents(self):
         """

--- a/partridge/parsers.py
+++ b/partridge/parsers.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date
+from datetime import datetime
 from functools import partial
 import numpy as np
 import pandas as pd
@@ -27,9 +27,6 @@ def parse_time(val):
 
 
 def parse_date(val):
-    if isinstance(val, date):
-        return val
-
     return datetime.strptime(val, DATE_FORMAT).date()
 
 

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -232,11 +232,8 @@ def test_raw_feed(path, shapes):
 
 
 def test_missing_zip():
-    try:
+    with pytest.raises(AssertionError, message='File or path not found'):
         ptg.feed(fixture('missing.zip'))
-        assert False
-    except AssertionError as err:
-        assert 'File or path not found' in repr(err)
 
 
 def test_config_must_be_dag():
@@ -247,11 +244,9 @@ def test_config_must_be_dag():
     # Make a cycle
     config.add_edge('trips.txt', 'routes.txt')
 
-    try:
-        path = zip_file('amazon-2017-08-06')
+    path = zip_file('amazon-2017-08-06')
+    with pytest.raises(AssertionError, message='Config must be a DAG'):
         ptg.feed(path, config=config)
-    except AssertionError as err:
-        assert 'Config must be a DAG' in repr(err)
 
 
 @pytest.mark.parametrize('path', [

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 import pytest
 
 import partridge as ptg
@@ -160,8 +159,7 @@ def test_read_file(path, dates, shapes):
         feed = ptg.feed(path)
 
     for filename, shape in shapes.items():
-        attrname, _ = os.path.splitext(filename)
-        assert getattr(feed, attrname).shape == shape, \
+        assert feed.get(filename).shape == shape, \
             '{}/{} dataframe shape was incorrect'.format(path, filename)
 
 
@@ -229,8 +227,7 @@ def test_raw_feed(path, shapes):
     feed = ptg.raw_feed(path)
 
     for filename, shape in shapes.items():
-        attrname, _ = os.path.splitext(filename)
-        assert getattr(feed, attrname).shape == shape, \
+        assert feed.get(filename).shape == shape, \
             '{}/{} dataframe shape was incorrect'.format(path, filename)
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,6 +1,6 @@
 import datetime
 import numpy as np
-
+import pytest
 
 from partridge.parsers import \
     parse_time, parse_date, \
@@ -12,19 +12,13 @@ def test_parse_date():
 
 
 def test_parse_date_with_invalid_month():
-    try:
+    with pytest.raises(ValueError, message='unconverted data remains: 01'):
         parse_date('20991401')
-        assert False
-    except ValueError as e:
-        assert 'unconverted data remains: 01' in repr(e)
 
 
 def test_parse_date_with_invalid_day():
-    try:
+    with pytest.raises(ValueError, message='unconverted data remains: 3'):
         parse_date('20990133')
-        assert False
-    except ValueError as e:
-        assert 'unconverted data remains: 3' in repr(e)
 
 
 def test_vparse_date():
@@ -46,11 +40,8 @@ def test_parse_time():
 
 
 def test_parse_time_with_invalid_input():
-    try:
+    with pytest.raises(ValueError, message='invalid literal for int()'):
         parse_time('10:15:00am')
-        assert False
-    except ValueError as e:
-        assert 'invalid literal for int()' in repr(e)
 
 
 def test_vparse_time():

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -9,7 +9,6 @@ from partridge.parsers import \
 
 def test_parse_date():
     assert parse_date('20990101') == datetime.date(2099, 1, 1)
-    assert parse_date(datetime.date(2099, 1, 1)) == datetime.date(2099, 1, 1)
 
 
 def test_parse_date_with_invalid_month():
@@ -33,7 +32,6 @@ def test_vparse_date():
     dateobjs = [datetime.date(2099, 1, 1), datetime.date(2099, 1, 2)]
 
     assert np.array_equal(vparse_date(np.array(datestrs)), dateobjs)
-    assert np.array_equal(vparse_date(np.array(dateobjs)), dateobjs)
 
 
 def test_parse_time():

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -46,17 +46,15 @@ def test_extract_agencies(path):
 
         nodes = []
         for node in fd.config.nodes():
-            attrname, _ = os.path.splitext(node)
-            df = getattr(fd, attrname)
+            df = fd.get(node)
             if not df.empty:
                 nodes.append(node)
 
         assert len(nodes)
 
         for node in nodes:
-            attrname, _ = os.path.splitext(node)
-            original_df = getattr(fd, attrname)
-            new_df = getattr(new_fd, attrname)
+            original_df = fd.get(node)
+            new_df = new_fd.get(node)
             assert set(original_df.columns) == set(new_df.columns)
 
     finally:
@@ -101,17 +99,15 @@ def test_extract_routes(path):
 
         nodes = []
         for node in fd.config.nodes():
-            attrname, _ = os.path.splitext(node)
-            df = getattr(fd, attrname)
+            df = fd.get(node)
             if not df.empty:
                 nodes.append(node)
 
         assert len(nodes)
 
         for node in nodes:
-            attrname, _ = os.path.splitext(node)
-            original_df = getattr(fd, attrname)
-            new_df = getattr(new_fd, attrname)
+            original_df = fd.get(node)
+            new_df = new_fd.get(node)
             assert set(original_df.columns) == set(new_df.columns)
 
     finally:


### PR DESCRIPTION
General cleanup of the codebase.

Small behavior change: `parse_date` and `vparse_date` only accept strings as input. This would only affect you if you're using these functions directly for some special use case.