### PR TITLE
Specify functools32 for Python < 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ with io.open('partridge/__version__.py', 'r', encoding='utf-8') as f:
     exec(f.read(), about)
 
 requirements = [
+    'functools32;python_version<"3"',
     'networkx>=2.0',
     'pandas',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements_dev.txt
-    py27: functools32
 commands =
     pip install -U pip
     py.test --basetemp={envtmpdir}


### PR DESCRIPTION
Add a functools32 dependency with a [PEP 508](https://www.python.org/dev/peps/pep-0508/) dependency specifier that limits it to Python 2.