### PR TITLE
Limit the number of lines read to detect character encoding

### DIFF
--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -60,5 +60,5 @@ def detect_encoding(f, limit=100):
     u.close()
     if u.result['encoding'] == 'ascii':
         return 'utf-8'
-    else: 
+    else:
         return u.result['encoding']

--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -47,12 +47,15 @@ def remove_node_attributes(G, attributes):
     return G
 
 
-def detect_encoding(f):
+def detect_encoding(f, limit=100):
     u = UniversalDetector()
     for line in f:
         line = bytearray(line)
         u.feed(line)
-        if u.done:
+
+        limit -= 1
+        if u.done or limit < 1:
             break
+
     u.close()
     return u.result['encoding']

--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -58,4 +58,7 @@ def detect_encoding(f, limit=100):
             break
 
     u.close()
-    return u.result['encoding']
+    if u.result['encoding'] == 'ascii':
+        return 'utf-8'
+    else: 
+        return u.result['encoding']


### PR DESCRIPTION
I'd like to get opinions from @cjer, @kuanb, and @tilgovi on this PR to address the performance issues raised in #39.

The underlying issue is that partridge checks the `done` flag on instances of `chardet. UniversalDetector` to determine whether to continue reading lines. As long as the minimum confidence threshold is not met the `done` flag is `False`. In many (most?) cases the entire file is being read out... ugh.

I don't want to remove encoding detection entirely because it is useful (see the test case), so I propose choosing an arbitrary limit of ~20~ 100 lines. That's enough to keep the tests passing while minimizing the performance overhead. It also doesn't require any changes to the partridge API.

We can investigate further and work towards a more complete solution, but I'd like to resolve the performance issues right away. I'm open to any and all feedback on this change.