### PR TITLE
Write feeds concurrently to reduce the overall time

### DIFF
--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -62,8 +62,13 @@ class feed(object):
     transfers = read_file('transfers.txt')
     trips = read_file('trips.txt')
 
-    @lru_method_cache(maxsize=None)
     def get(self, filename):
+        lock = self._locks.get(filename, self._shared_lock)
+        with lock:
+            return self._get(filename)
+
+    @lru_method_cache(maxsize=None)
+    def _get(self, filename):
         config = self.config
 
         # Get config for node

--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -8,7 +8,12 @@ import numpy as np
 import pandas as pd
 
 from partridge.config import default_config, empty_config
-from partridge.utilities import empty_df, detect_encoding, lru_cache, setwrap
+from partridge.utilities import (
+    empty_df,
+    detect_encoding,
+    lru_method_cache,
+    setwrap,
+)
 
 
 def read_file(filename):
@@ -54,7 +59,7 @@ class feed(object):
     transfers = read_file('transfers.txt')
     trips = read_file('trips.txt')
 
-    @lru_cache(maxsize=None)
+    @lru_method_cache(maxsize=None)
     def get(self, filename):
         config = self.config
 

--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -36,9 +36,9 @@ class feed(object):
                 'of the config graph: {} {}'.format(filename, param)
 
         if self.is_dir:
-            self._verify_folder_contents()
+            self._prepare_folder_contents()
         else:
-            self._verify_zip_contents()
+            self._prepare_zip_contents()
 
     agency = read_file('agency.txt')
     calendar = read_file('calendar.txt')
@@ -168,7 +168,7 @@ class feed(object):
                     with io.TextIOWrapper(zfile, encoding) as iowrapper:
                         yield iowrapper, encoding
 
-    def _verify_zip_contents(self):
+    def _prepare_zip_contents(self):
         """
         Verify that the folder does not contain multiple files
         of the same name. Load file paths into internal dictionary.
@@ -186,7 +186,7 @@ class feed(object):
                     'More than one {} in zip'.format(basename)
                 self.zmap[basename] = entry.filename
 
-    def _verify_folder_contents(self):
+    def _prepare_folder_contents(self):
         """
         Verify that the folder does not contain multiple files
         of the same name. Load file paths into internal dictionary.


### PR DESCRIPTION
Uses a thread-per-file to reduce to overall time to
roughly the time of the largest file, plus some overhead.

Already covered by unit tests.