### PR TITLE
Bug fix: Preserve complete trips by resolving trip_ids from filters

### DIFF
--- a/partridge/readers.py
+++ b/partridge/readers.py
@@ -106,12 +106,16 @@ def _unpack_feed(path: str, view: View, config: nx.DiGraph) -> Feed:
 def _load_feed(path: str, view: View, config: nx.DiGraph) -> Feed:
     """Multi-file feed filtering"""
     config_ = remove_node_attributes(config, ["converters", "transformations"])
-    feed_ = Feed(path, view={}, config=config_)
+    trip_ids = set(Feed(path, config=config_).trips.trip_id)
     for filename, column_filters in view.items():
-        config_ = reroot_graph(config_, filename)
-        view_ = {filename: column_filters}
-        feed_ = Feed(feed_, view=view_, config=config_)
-    return Feed(feed_, config=config)
+        trip_ids &= set(
+            Feed(
+                path,
+                view={filename: column_filters},
+                config=reroot_graph(config_, filename),
+            ).trips.trip_id
+        )
+    return Feed(path, view={"trips.txt": {"trip_id": trip_ids}}, config=config)
 
 
 def _busiest_date(feed: Feed) -> Tuple[datetime.date, FrozenSet[str]]:

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -14,6 +14,15 @@ def test_load_feed():
     assert feed.stop_times.dtypes["arrival_time"] == np.float64
 
 
+def test_load_feed_with_view():
+    full_feed = ptg.load_feed(fixture("trimet-vermont-2018-02-06"))
+    assert full_feed.stops.shape[0] == 102
+
+    view = {"stops.txt": {"stop_id": full_feed.stops.stop_id[0]}}
+    feed = ptg.load_feed(fixture("trimet-vermont-2018-02-06"), view=view)
+    assert feed.stops.stop_id.shape[0] == 72
+
+
 def test_load_geo_feed():
     gpd = pytest.importorskip("geopandas")
 


### PR DESCRIPTION
Pre-1.0 versions of partridge preserved relationally-complete trips by resolving each filter clause to a set of reachable trip_ids. This behavior was mistakenly changed in the 1.0 refactor. You could be affected if you use partridge to filter by stop_times.txt or an ancestor of stop_times.txt in the dependency graph. This use case seems uncommon in practice.

To reproduce the issue, filter stops.txt by some field and observe that only stops matching the filter are kept, potentially leaving trips with missing stops. See the test case for details.

TODO
- [ ] review
- [ ] merge
- [ ] release