### PR TITLE
Remove usage of deprecated numpy types

### DIFF
--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -3,7 +3,6 @@ from threading import RLock
 from typing import Dict, Optional, Union
 
 import networkx as nx
-import numpy as np
 import pandas as pd
 
 from .config import default_config
@@ -99,7 +98,7 @@ class Feed(object):
         with open(path, "rb") as f:
             encoding = detect_encoding(f)
 
-        df = pd.read_csv(path, dtype=np.unicode, encoding=encoding, index_col=False)
+        df = pd.read_csv(path, dtype=str, encoding=encoding, index_col=False)
 
         # Strip leading/trailing whitespace from column names
         df.rename(columns=lambda x: x.strip(), inplace=True)

--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, Iterable, Optional, Set, BinaryIO, Union
 
 from cchardet import UniversalDetector
 import networkx as nx
-import numpy as np
 import pandas as pd
 from pandas.core.common import flatten
 
@@ -67,4 +66,4 @@ def detect_encoding(f: BinaryIO, limit: int = 2500) -> str:
 def empty_df(columns: Optional[Iterable[str]] = None) -> pd.DataFrame:
     columns = [] if columns is None else columns
     empty: Dict = {col: [] for col in columns}
-    return pd.DataFrame(empty, columns=columns, dtype=np.unicode)
+    return pd.DataFrame(empty, columns=columns, dtype=str)

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -9,7 +9,7 @@ from .helpers import fixture, zip_file
 
 def test_load_feed():
     feed = ptg.load_feed(fixture("amazon-2017-08-06"))
-    assert feed.stop_times.dtypes["stop_id"] == np.object
+    assert feed.stop_times.dtypes["stop_id"] == object
     assert feed.stop_times.dtypes["stop_sequence"] == np.int64
     assert feed.stop_times.dtypes["arrival_time"] == np.float64
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -2,7 +2,6 @@ import io
 import networkx as nx
 import pytest
 
-import numpy as np
 import pandas as pd
 from partridge.utilities import (
     detect_encoding,
@@ -44,7 +43,7 @@ def test_empty_df():
     actual = empty_df(["foo", "bar"])
 
     expected = pd.DataFrame(
-        {"foo": [], "bar": []}, columns=["foo", "bar"], dtype=np.unicode
+        {"foo": [], "bar": []}, columns=["foo", "bar"], dtype=str
     )
 
     assert actual.equals(expected)


### PR DESCRIPTION
- Closes #68 
- Switch from `np.unicode` to `str` as numpy 1.20.0 introduced a bug with `np.unicode`
- Switch from `np.object` to `object` as the former is deprecated
- `python setup.py test` had 30 failed tests prior to change, now all passed with change 
- @invisiblefunnel @timhowgego review appreciated, cheers