### PR TITLE
Migrate from init proj4 type projection

### DIFF
--- a/partridge/geo.py
+++ b/partridge/geo.py
@@ -11,7 +11,7 @@ except ImportError as impexc:
     raise
 
 
-DEFAULT_CRS = {"init": "EPSG:4326"}
+DEFAULT_CRS = "EPSG:4326"
 
 
 def build_shapes(df: pd.DataFrame) -> gpd.GeoDataFrame:
@@ -36,4 +36,4 @@ def build_stops(df: pd.DataFrame) -> gpd.GeoDataFrame:
 
     df.drop(["stop_lon", "stop_lat"], axis=1, inplace=True)
 
-    return gpd.GeoDataFrame(df, crs={"init": "EPSG:4326"})
+    return gpd.GeoDataFrame(df, crs=DEFAULT_CRS)

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -22,8 +22,8 @@ def test_load_geo_feed():
     assert isinstance(feed.stops, gpd.GeoDataFrame)
     assert {"LineString"} == set(feed.shapes.geom_type)
     assert {"Point"} == set(feed.stops.geom_type)
-    assert feed.shapes.crs == {"init": "EPSG:4326"}
-    assert feed.stops.crs == {"init": "EPSG:4326"}
+    assert feed.shapes.crs == "EPSG:4326"
+    assert feed.stops.crs == "EPSG:4326"
     assert ["shape_id", "geometry"] == list(feed.shapes.columns)
     assert [
         "stop_id",


### PR DESCRIPTION
Starting with GeoPandas 0.7, the "init" proj4 string type projection is no longer in use. Using the "init" style throws a deprecation warning. Although it does not break the code at the moment, it is recommended to change. See GeoPandas Documentation regarding this [here](https://geopandas.org/en/stable/docs/user_guide/projections.html)