### PR TITLE
rollback to chardet to support python 3.10+

### DIFF
--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Iterable, Optional, Set, BinaryIO, Union
 
-from cchardet import UniversalDetector
+from chardet import UniversalDetector
 import networkx as nx
 import numpy as np
 import pandas as pd
@@ -56,6 +56,7 @@ def detect_encoding(f: BinaryIO, limit: int = 2500) -> str:
     u = UniversalDetector()
 
     for line_no, line in enumerate(f):
+        line = bytearray(line)
         u.feed(line)
         if u.done or line_no > limit:
             break

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with io.open("partridge/__version__.py", "r", encoding="utf-8") as f:
     exec(f.read(), about)
 
 requirements = [
-    "cchardet",
+    "chardet",
     'functools32;python_version<"3"',
     "networkx>=2.0",
     "pandas",

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -55,7 +55,7 @@ def test_empty_df():
     [
         (b"abcde", "utf-8"),  # straight up ascii is a subset of unicode
         (b"Eyjafjallaj\xc3\xb6kull", "utf-8"),  # actual unicode
-        (b"\xC4pple", "WINDOWS-1252"),  # non-unicode, ISO characterset
+        (b"\xC4pple", "ISO-8859-1"),  # non-unicode, ISO characterset
     ],
 )
 def test_detect_encoding(test_string, encoding):


### PR DESCRIPTION
Rollsback partridge to use chardet instead of cchardet.  Due to this issue: https://github.com/remix/partridge/issues/73

Potential alternative fix: https://github.com/remix/partridge/pull/76

