### PR TITLE
switch to charset_normalizer for encoding to support py 3.10+

### DIFF
--- a/partridge/utilities.py
+++ b/partridge/utilities.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Iterable, Optional, Set, BinaryIO, Union
 
-from cchardet import UniversalDetector
+from charset_normalizer import detect
 import networkx as nx
 import numpy as np
 import pandas as pd
@@ -53,15 +53,7 @@ def detect_encoding(f: BinaryIO, limit: int = 2500) -> str:
         return "utf-8"
 
     f.seek(0)
-    u = UniversalDetector()
-
-    for line_no, line in enumerate(f):
-        u.feed(line)
-        if u.done or line_no > limit:
-            break
-
-    u.close()
-    return u.result["encoding"]
+    return detect(f.read())["encoding"]
 
 
 def empty_df(columns: Optional[Iterable[str]] = None) -> pd.DataFrame:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with io.open("partridge/__version__.py", "r", encoding="utf-8") as f:
     exec(f.read(), about)
 
 requirements = [
-    "cchardet",
+    "charset_normalizer",
     'functools32;python_version<"3"',
     "networkx>=2.0",
     "pandas",

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -55,7 +55,7 @@ def test_empty_df():
     [
         (b"abcde", "utf-8"),  # straight up ascii is a subset of unicode
         (b"Eyjafjallaj\xc3\xb6kull", "utf-8"),  # actual unicode
-        (b"\xC4pple", "WINDOWS-1252"),  # non-unicode, ISO characterset
+        (b"\xC4pple", "cp037"),  # non-unicode, ISO characterset
     ],
 )
 def test_detect_encoding(test_string, encoding):


### PR DESCRIPTION
Switches partridge to use charset_normalizer instead of cchardet. 

Due to this issue: https://github.com/remix/partridge/issues/73

Potential alternative fix: https://github.com/remix/partridge/pull/75