### PR TITLE
Replace np.unicode with str

### DIFF
--- a/partridge/gtfs.py
+++ b/partridge/gtfs.py
@@ -99,7 +99,7 @@ class Feed(object):
         with open(path, "rb") as f:
             encoding = detect_encoding(f)
 
-        df = pd.read_csv(path, dtype=np.unicode, encoding=encoding, index_col=False)
+        df = pd.read_csv(path, dtype=str, encoding=encoding, index_col=False)
 
         # Strip leading/trailing whitespace from column names
         df.rename(columns=lambda x: x.strip(), inplace=True)


### PR DESCRIPTION
This PR is a small fix so that partridge is compatible with Numpy 1.2+

This is necessary b/c of [numpy types deprecation]( https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)

Fixes issue #77 