### PR TITLE
add support for parsing of invalid time with only hours and minutes

### DIFF
--- a/partridge/parsers.py
+++ b/partridge/parsers.py
@@ -16,7 +16,12 @@ def parse_time(val: str) -> np.float64:
     if val == "":
         return np.nan
 
-    h, m, s = val.split(":")
+    h, m, *s = val.split(":")
+    if len(s) == 0:
+        s = "0"
+    else:
+        assert len(s) == 1
+        s = s[0]
     ssm = int(h) * 3600 + int(m) * 60 + int(s)
 
     # pandas doesn't have a NaN int, use floats

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -36,6 +36,10 @@ def test_parse_time():
     assert parse_time("1:02:03") == 3723
     assert parse_time("25:24:23") == 91463
     assert parse_time("250:24:23") == 901463
+    assert parse_time("00:00") == 0
+    assert parse_time("0:00") == 0
+    assert parse_time("01:02") == 3720
+    assert parse_time("1:02") == 3720
 
 
 def test_parse_time_with_invalid_input():


### PR DESCRIPTION
In Israel GTFS data we encountered stop_times data with non-standard time values HH:MM (without seconds), so I added support for this format